### PR TITLE
Improvements to tenant PR

### DIFF
--- a/auth0/resource_auth0_email.go
+++ b/auth0/resource_auth0_email.go
@@ -41,16 +41,18 @@ func newEmail() *schema.Resource {
 							Optional: true,
 						},
 						"api_key": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
 						},
 						"access_key_id": {
 							Type:     schema.TypeString,
 							Optional: true,
 						},
 						"secret_access_key": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
 						},
 						"region": {
 							Type:     schema.TypeString,
@@ -69,8 +71,9 @@ func newEmail() *schema.Resource {
 							Optional: true,
 						},
 						"smtp_pass": {
-							Type:     schema.TypeString,
-							Optional: true,
+							Type:      schema.TypeString,
+							Optional:  true,
+							Sensitive: true,
 						},
 					},
 				},

--- a/auth0/resource_auth0_tenant_test.go
+++ b/auth0/resource_auth0_tenant_test.go
@@ -44,28 +44,28 @@ provider "auth0" {}
 
 resource "auth0_tenant" "my_tenant" {
 	change_password {
-	  enabled = true
-	  html = "<html>Change Password</html>"
+		enabled = true
+		html = "<html>Change Password</html>"
 	}
 	guardian_mfa_page {
-	  enabled = true
-	  html = "<html>MFA</html>"
+		enabled = true
+		html = "<html>MFA</html>"
 	}
 	default_audience = ""
 	default_directory = ""
 	error_page {
-	  html = "<html>Error Page</html>",
-	  show_log_link = false,
-	  url = "https://mycompany.org/error"
+		html = "<html>Error Page</html>",
+		show_log_link = false,
+		url = "https://mycompany.org/error"
 	}
 	friendly_name = "My Test Tenant"
 	picture_url = "https://mycompany.org/logo.png"
 	support_email = "support@mycompany.org"
 	support_url = "https://mycompany.org/support"
 	allowed_logout_urls = [
-	  "https://mycompany.org/logoutCallback"
+		"https://mycompany.org/logoutCallback"
 	]
 	session_lifetime = 168,
 	sandbox_version = "8"
-  }
+}
 `


### PR DESCRIPTION
Hi @omar, I've tested locally and it seems to relate to the nested values being read incorrectly. Being a list means we have to define nested values as `[]map[string]interface{}` so it took a little bit of boilerplate to get those values in.

Additionally, I've replaced `readTenant` with `updateTenant` during the creation phase. Otherwise the values we set in the `.tf` config wouldn't reflect the remote values.

Cheers,
Alex